### PR TITLE
Update to Node.js v4.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM heroku/cedar:14
 
 # Set Node Version
-ENV NODE_ENGINE 4.4.6
+ENV NODE_ENGINE 4.4.7
 
 # Set the PATH for Node (inc npm) and any installed runnables
 ENV PATH /app/heroku/node/bin/:/app/user/node_modules/.bin:$PATH

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This hasn't happened yet and so I'm not totally sure exactly which builds get re
 The Dockerfile in your project should look something like this for basic usage
 
 ```
-FROM FROM binarytales/heroku-nodejs:5.6.0
+FROM binarytales/heroku-nodejs:5.6.0
 
 ADD package.json /app/user/
 RUN /app/heroku/node/bin/npm install


### PR DESCRIPTION
hi @Binarytales 
Heroku now can deploy origin docker container without inherited from cedar. 
so I think this repo's maintenance no need continues.
